### PR TITLE
fix: use correct threlte url, misc typo fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -241,7 +241,7 @@
 
 ### Svelte
 
-- [Threlte](https://github.com/grischaerbe/threlte): A three.js component library for Svelte
+- [Threlte](https://github.com/threlte/threlte): A three.js component library for Svelte
 - [svelte-cubed](https://github.com/Rich-Harris/svelte-cubed): Declarative ThreeJS for Svelte
   by [@Rich-Harris](https://github.com/Rich-Harris)
 - [threlte-postprocessing](https://github.com/1bye/threlte-postprocessing): A postprocessing wrapper for Threlte by [@1bye](https://github.com/1bye)
@@ -263,8 +263,8 @@
 
 ## Pathfinding
 
-- [Pathfinging.js](https://github.com/qiao/PathFinding.js) Useful library with tons of settings
-- [Three-pathfinging](https://github.com/donmccurdy/three-pathfinding) Three.js plugin for navigation
+- [Pathfinding.js](https://github.com/qiao/PathFinding.js) Useful library with tons of settings
+- [Three-pathfinding](https://github.com/donmccurdy/three-pathfinding) Three.js plugin for navigation
 - [Kompute](https://github.com/oguzeroglu/Kompute) Easy to use steering library
 
 ## Characters


### PR DESCRIPTION
- Update the threlte url to use the official repo instead of a fork
- Fixes typos under the "Pathfinding" section