### PR TITLE
Add KGEngine to Related Frameworks

### DIFF
--- a/README.md
+++ b/README.md
@@ -218,6 +218,10 @@
 
 ## Related Frameworks
 
+### Framework Agnostic
+
+- [KGEngine](https://github.com/KANTNOLI/kgengine): A high-level 3D engine built on THREE.js with simplified API, built-in shader system, object management, and ready-to-use components. **Key feature: native HTML/CSS elements embedded directly into 3D space with proper depth, occlusion, and camera interaction.** Works with any framework (React, Vue, Svelte, Angular, or vanilla JS). Open source (GPLv3). by [@KANTNOLI](https://github.com/KANTNOLI)
+  
 ### React
 
 - [react-three-fiber](https://github.com/pmndrs/react-three-fiber): A declarative way of handling your ThreeJS stuff for


### PR DESCRIPTION
Add KGEngine - a high-level 3D engine based on THREE.js with simplified API and shader system

- **Category:** Related Frameworks
- **Reason:** KGEngine is a framework/abstraction layer over THREE.js, similar to react-three-fiber or trois, but framework-agnostic.
- **License:** GPLv3
- **Author:** KANTNOLI Production